### PR TITLE
Feat: block users without sessions

### DIFF
--- a/src/api/back-in-stock.resolver.ts
+++ b/src/api/back-in-stock.resolver.ts
@@ -1,5 +1,6 @@
 import { Args, Resolver, Query, Mutation } from '@nestjs/graphql';
-import { RequestContext, Ctx, ErrorResultUnion } from '@vendure/core';
+import { Inject } from '@nestjs/common';
+import { RequestContext, Ctx, ErrorResultUnion, PLUGIN_INIT_OPTIONS, ForbiddenError } from '@vendure/core';
 import { BackInStock } from '../entity/back-in-stock.entity';
 import { BackInStockService } from '../service/back-in-stock.service';
 import {
@@ -7,10 +8,14 @@ import {
     QueryActiveBackInStockSubscriptionForProductVariantWithCustomerArgs,
     CreateBackInStockSubscriptionResult,
 } from '../../generated/generated-shop-types';
+import { BackInStockOptions } from '../back-in-stock.plugin';
 
 @Resolver()
 export class BackInStockResolver {
-    constructor(private backInStockService: BackInStockService) {}
+    constructor(
+        private backInStockService: BackInStockService,
+        @Inject(PLUGIN_INIT_OPTIONS) private options: BackInStockOptions
+    ) { }
 
     @Query()
     async activeBackInStockSubscriptionForProductVariantWithCustomer(
@@ -29,6 +34,9 @@ export class BackInStockResolver {
         @Ctx() ctx: RequestContext,
         @Args() args: MutationCreateBackInStockSubscriptionArgs,
     ): Promise<ErrorResultUnion<CreateBackInStockSubscriptionResult, BackInStock>> {
+        if (!this.options.allowSubscriptionWithoutSession && ctx.session === undefined) {
+            throw new ForbiddenError();
+        }
         return this.backInStockService.create(ctx, args.input);
     }
 }

--- a/src/back-in-stock.plugin.ts
+++ b/src/back-in-stock.plugin.ts
@@ -27,6 +27,12 @@ import { getApiType } from '@vendure/core/dist/api/common/get-api-type';
 export interface BackInStockOptions {
     enableEmail: boolean;
     limitEmailToStock: boolean;
+    /**
+     * Allow subscribing to out of stock emails for calls without a session. Defaults to true.
+     * With allowSubscriptionWithoutSession=true anyone can subscribe to out of stock emails, 
+     * even when the caller doesn't have an active session
+     */
+    allowSubscriptionWithoutSession?: boolean;
 }
 
 /**
@@ -116,6 +122,9 @@ export class BackInStockPlugin {
     };
 
     static init(options: BackInStockOptions): typeof BackInStockPlugin {
+        if (options.allowSubscriptionWithoutSession === undefined) {
+            options.allowSubscriptionWithoutSession = true;
+        }
         this.options = options;
         return BackInStockPlugin;
     }


### PR DESCRIPTION
This PR allows you to configure the plugin to block any calls to the `createBackInStockSubscription` mutation that do not have a session attached. We would like to do this as some sort of spam prevention: Only users with an active session should be able to create subscriptions.

Example
```diff
    BackInStockPlugin.init({
      enableEmail: true,
      limitEmailToStock: false
+    allowSubscriptionWithoutSession: false
    })
```

The config option is optional and defaults to `true`, so this change is not breaking.